### PR TITLE
Fix build include path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ fn main() -> Result<()> {
         .extern_path(".google.protobuf.Timestamp", "::prost_wkt_types::Timestamp")
         .extern_path(".google.protobuf.Value", "::prost_wkt_types::Value")
         .file_descriptor_set_path(&descriptor_file)
-        .compile_protos(&["src/protos/block.proto"], &["proto/"])
+        .compile_protos(&["src/protos/block.proto"], &["src/"])
         .unwrap();
 
     let descriptor_bytes = std::fs::read(descriptor_file).unwrap();


### PR DESCRIPTION
`flat-files-decoder` couldn't build when using `sf-protos` as a dependency. This should fix it.